### PR TITLE
Fix while loops actually blocking and running

### DIFF
--- a/editor/worker.js
+++ b/editor/worker.js
@@ -248,9 +248,9 @@ if (!emu.running) { return null; }
 if ((${condition}) === false) { return null; }
 ${inject(body)}
 await new Promise(resolve => setTimeout(resolve, 0))
-___WHILE_${W}()
+await ___WHILE_${W}()
 }
-___WHILE_${W}()`
+await ___WHILE_${W}()`
     }
     case 'ReturnStatement': {
       const value = node.value !== undefined ? ast_node_to_js(node.value) : '';


### PR DESCRIPTION
While the actual function of a while loop was changed to be async, the way it is called and calls itself again causes the function to not block the main worker thread and just run the loop in the background, which isn't what I would expect from a while loop.
This change should fix this and make it so the while loop actually runs until either the condition is false or the emulator is stopped.

Edit: I know that a new editor will be released soon, but I wanted to continue working on my project in the current one until its released. If this pull request is going to be merged after the upgrade, feel free to close it instead.