### PR TITLE
Fix: Replace unpkg.com CDN with jsdelivr for Tone

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -114,7 +114,7 @@
     </main>
     <script src="codemirror.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/victus@0.12.0/build/victus.min.js"></script>
-    <script src="https://unpkg.com/tone" crossorigin></script>
+    <script src="https://cdn.jsdelivr.net/npm/tone/build/Tone.min.js" crossorigin></script>
     <script src="docs.js"></script>
     <script src="messages.js" type="module"></script>
     <script src="script.js" type="module"></script>

--- a/editor/old/index.html
+++ b/editor/old/index.html
@@ -96,7 +96,7 @@
     </main>
     <script src="codemirror.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/victus@0.12.0/build/victus.min.js"></script>
-    <script src="https://unpkg.com/tone" crossorigin></script>
+    <script src="https://cdn.jsdelivr.net/npm/tone/build/Tone.min.js" crossorigin></script>
     <script src="docs.js"></script>
     <script src="messages.js" type="module"></script>
     <script src="script.js" type="module"></script>

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
       </center>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/victus@0.12.0/build/victus.min.js"></script>
-    <script src="https://unpkg.com/tone"></script>
+    <script src="https://cdn.jsdelivr.net/npm/tone/build/Tone.min.js"></script>
     <script src="script.js"></script>
   </body>
 


### PR DESCRIPTION
Replace unpkg.com/tone with cdn.jsdelivr.net/npm/tone/build/Tone.min.js to resolve loading errors. The unpkg service is currently experiencing outages causing 520 errors and preventing the editor from running due to missing Tone.js dependency.